### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/323/57/85632357.geojson
+++ b/data/856/323/57/85632357.geojson
@@ -962,6 +962,11 @@
     },
     "wof:country":"MU",
     "wof:country_alpha3":"MUS",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"4fe885c36b72aa680ac267a8faac09bc",
     "wof:hierarchy":[
         {
@@ -978,7 +983,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1566612094,
+    "wof:lastmodified":1582332264,
     "wof:name":"Mauritius",
     "wof:parent_id":102193527,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.