### PR TITLE
mu concordances, placetype local, and more

### DIFF
--- a/data/856/323/57/85632357.geojson
+++ b/data/856/323/57/85632357.geojson
@@ -1157,6 +1157,7 @@
         "hasc:id":"MU",
         "icao:code":"3B",
         "ioc:id":"MRI",
+        "iso:code":"MU",
         "itu:id":"MAU",
         "loc:id":"n79060078",
         "m49:code":"480",
@@ -1171,6 +1172,7 @@
         "wk:page":"Mauritius",
         "wmo:id":"MA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
     "wof:country_alpha3":"MUS",
     "wof:geom_alt":[
@@ -1194,7 +1196,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Mauritius",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/749/25/85674925.geojson
+++ b/data/856/749/25/85674925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001158,
-    "geom:area_square_m":14080004.522058,
+    "geom:area_square_m":14080345.037593,
     "geom:bbox":"56.524181,-10.406508,56.569347,-10.323907",
     "geom:latitude":-10.362172,
     "geom:longitude":56.545544,
@@ -295,14 +295,16 @@
         "gn:id":448254,
         "gp:id":2346237,
         "hasc:id":"MU.AG",
+        "iso:code":"MU-AG",
         "iso:id":"MU-AG",
         "qs_pg:id":1311326,
         "unlc:id":"MU-AG",
         "wd:id":"Q196042",
         "wk:page":"Agal\u00e9ga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"4d8decc00952db994a2b948af03020b4",
+    "wof:geomhash":"9a64738215b27bb3ff9a1756a3662ab2",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -319,7 +321,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846512,
+    "wof:lastmodified":1695884325,
     "wof:name":"Agal\u00e9ga",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/29/85674929.geojson
+++ b/data/856/749/29/85674929.geojson
@@ -216,11 +216,13 @@
         "gn:id":934765,
         "gp:id":1377240,
         "hasc:id":"MU.",
+        "iso:code":"MU-BR",
         "qs_pg:id":229253,
         "unlc:id":"MU-BR",
         "wd:id":"Q813337",
         "wk:page":"Beau Bassin-Rose Hill"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
     "wof:geomhash":"5e4870931a3cc2bcafeed11b56c3ba59",
     "wof:hierarchy":[
@@ -239,7 +241,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Beau Bassin-Rose Hill",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/35/85674935.geojson
+++ b/data/856/749/35/85674935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000023,
-    "geom:area_square_m":274627.107081,
+    "geom:area_square_m":274664.937355,
     "geom:bbox":"59.492035,-16.820896,59.697032,-16.423679",
     "geom:latitude":-16.687398,
     "geom:longitude":59.564381,
@@ -153,11 +153,13 @@
         "gn:id":1106583,
         "gp:id":2346238,
         "hasc:id":"MU.CC",
+        "iso:code":"MU-CC",
         "iso:id":"MU-CC",
         "qs_pg:id":1311327
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"0683ec6b0e5869b78a569b41435a0c73",
+    "wof:geomhash":"d3b10776a9485e5102235ff199fab76f",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -174,7 +176,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1614895145,
+    "wof:lastmodified":1695884523,
     "wof:name":"Cargados Carajos Shoals",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/39/85674939.geojson
+++ b/data/856/749/39/85674939.geojson
@@ -229,10 +229,12 @@
         "gn:id":-934166,
         "gp:id":1377308,
         "hasc:id":"MU.",
+        "iso:code":"MU-CU",
         "qs_pg:id":920353,
         "unlc:id":"MU-CU",
         "wd:id":"Q1002525"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
     "wof:geomhash":"bf2788b7d6a2c0ebaafd37197bdb2e93",
     "wof:hierarchy":[
@@ -251,7 +253,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884286,
     "wof:name":"Curepipe",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/43/85674943.geojson
+++ b/data/856/749/43/85674943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026118,
-    "geom:area_square_m":303059971.092632,
+    "geom:area_square_m":303060170.093846,
     "geom:bbox":"57.607224,-20.328396,57.795746,-20.096124",
     "geom:latitude":-20.218458,
     "geom:longitude":57.710745,
@@ -278,14 +278,16 @@
         "gn:id":934522,
         "gp:id":2346229,
         "hasc:id":"MU.FL",
+        "iso:code":"MU-FL",
         "iso:id":"MU-FL",
         "qs_pg:id":318528,
         "unlc:id":"MU-FL",
         "wd:id":"Q911651",
         "wk:page":"Flacq District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"db3b08011a3c7a226f9f37a0e523ee3f",
+    "wof:geomhash":"9f667a159afe83950613e28fc971528d",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -302,7 +304,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846510,
+    "wof:lastmodified":1695884855,
     "wof:name":"Flacq",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/47/85674947.geojson
+++ b/data/856/749/47/85674947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01916,
-    "geom:area_square_m":222074859.336182,
+    "geom:area_square_m":222074663.057433,
     "geom:bbox":"57.546013,-20.49204,57.781505,-20.302624",
     "geom:latitude":-20.39078,
     "geom:longitude":57.666018,
@@ -275,14 +275,16 @@
         "gn:id":934466,
         "gp:id":2346230,
         "hasc:id":"MU.GP",
+        "iso:code":"MU-GP",
         "iso:id":"MU-GP",
         "qs_pg:id":318531,
         "unlc:id":"MU-GP",
         "wd:id":"Q911635",
         "wk:page":"Grand Port District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"89324d65db06ec2a0c16c98c063d58a4",
+    "wof:geomhash":"e3a30b1f10357947a79945b7ab80e836",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -299,7 +301,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846512,
+    "wof:lastmodified":1695884855,
     "wof:name":"Grand Port",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/53/85674953.geojson
+++ b/data/856/749/53/85674953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01787,
-    "geom:area_square_m":207297990.299379,
+    "geom:area_square_m":207297781.484521,
     "geom:bbox":"57.485877,-20.344504,57.679173,-20.184498",
     "geom:latitude":-20.259005,
     "geom:longitude":57.591335,
@@ -275,14 +275,16 @@
         "gn:id":934275,
         "gp:id":2346231,
         "hasc:id":"MU.MO",
+        "iso:code":"MU-MO",
         "iso:id":"MU-MO",
         "qs_pg:id":318532,
         "unlc:id":"MU-MO",
         "wd:id":"Q911643",
         "wk:page":"Moka District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"2d21cbdd5be99546bba191a72b0f2306",
+    "wof:geomhash":"0b01828e2444c43ea8f5fbc78546f58b",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -299,7 +301,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846510,
+    "wof:lastmodified":1695884855,
     "wof:name":"Moka",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/57/85674957.geojson
+++ b/data/856/749/57/85674957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016949,
-    "geom:area_square_m":196809661.812658,
+    "geom:area_square_m":196809289.19095,
     "geom:bbox":"57.493826,-20.204902,57.635144,-19.999933",
     "geom:latitude":-20.099094,
     "geom:longitude":57.56981,
@@ -290,14 +290,16 @@
         "gn:id":934212,
         "gp:id":2346232,
         "hasc:id":"MU.PA",
+        "iso:code":"MU-PA",
         "iso:id":"MU-PA",
         "qs_pg:id":318533,
         "unlc:id":"MU-PA",
         "wd:id":"Q934126",
         "wk:page":"Pamplemousses District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"4729ecd5d426ce2e09a4fb993783dcbb",
+    "wof:geomhash":"ea869e5e36d514cba9e4a2688e3c81cd",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -314,7 +316,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846509,
+    "wof:lastmodified":1695884855,
     "wof:name":"Pamplemousses",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/61/85674961.geojson
+++ b/data/856/749/61/85674961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012295,
-    "geom:area_square_m":142546206.772071,
+    "geom:area_square_m":142546546.360071,
     "geom:bbox":"57.448291,-20.425045,57.599707,-20.188794",
     "geom:latitude":-20.337178,
     "geom:longitude":57.518088,
@@ -281,14 +281,16 @@
         "gn:id":934166,
         "gp:id":2346233,
         "hasc:id":"MU.PW",
+        "iso:code":"MU-PW",
         "iso:id":"MU-PW",
         "qs_pg:id":235610,
         "unlc:id":"MU-PW",
         "wd:id":"Q1053595",
         "wk:page":"Plaines Wilhems District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"ecf555decd726547fb3ce3b3a653e0ad",
+    "wof:geomhash":"33886e08ed15f0853b72e1ded898e77e",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -305,7 +307,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846508,
+    "wof:lastmodified":1695884855,
     "wof:name":"Plaines Wilhems",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/65/85674965.geojson
+++ b/data/856/749/65/85674965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003418,
-    "geom:area_square_m":39677777.80682,
+    "geom:area_square_m":39677528.460318,
     "geom:bbox":"57.465407,-20.201959,57.550309,-20.122214",
     "geom:latitude":-20.164729,
     "geom:longitude":57.519332,
@@ -243,13 +243,15 @@
         "gn:id":934153,
         "gp:id":2346234,
         "hasc:id":"MU.PL",
+        "iso:code":"MU-PL",
         "iso:id":"MU-PL",
         "qs_pg:id":1083850,
         "wd:id":"Q960645",
         "wk:page":"Port Louis District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"eac9df93f31c32755f73a4f4aa12d667",
+    "wof:geomhash":"3249340cbb976d543cddb0229f3e2103",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -266,7 +268,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846510,
+    "wof:lastmodified":1695884855,
     "wof:name":"Port Louis",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/71/85674971.geojson
+++ b/data/856/749/71/85674971.geojson
@@ -472,11 +472,13 @@
     "wof:concordances":{
         "gn:id":934154,
         "gp:id":1377436,
+        "iso:code":"MU-PL",
         "loc:id":"n79090018",
         "qs_pg:id":219476,
         "wd:id":"Q960645",
         "wk:page":"Port Louis"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1125952633
     ],
@@ -498,7 +500,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884856,
     "wof:megacity":0,
     "wof:name":"Port Louis",
     "wof:parent_id":85632357,

--- a/data/856/749/75/85674975.geojson
+++ b/data/856/749/75/85674975.geojson
@@ -209,11 +209,13 @@
         "gn:id":934131,
         "gp:id":1377444,
         "hasc:id":"MU.",
+        "iso:code":"MU-QB",
         "qs_pg:id":1040807,
         "unlc:id":"MU-QB",
         "wd:id":"Q1341194",
         "wk:page":"Quatre Bornes"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
     "wof:geomhash":"fe6d9b4818995149b649f96826049c57",
     "wof:hierarchy":[
@@ -232,7 +234,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Quatre Bornes",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/79/85674979.geojson
+++ b/data/856/749/79/85674979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012581,
-    "geom:area_square_m":146129552.958523,
+    "geom:area_square_m":146130192.746915,
     "geom:bbox":"57.580333,-20.155504,57.733653,-19.979425",
     "geom:latitude":-20.060586,
     "geom:longitude":57.650885,
@@ -267,14 +267,16 @@
         "gn:id":934090,
         "gp:id":2346235,
         "hasc:id":"MU.RR",
+        "iso:code":"MU-RR",
         "iso:id":"MU-RR",
         "qs_pg:id":1083851,
         "unlc:id":"MU-RR",
         "wd:id":"Q1053565",
         "wk:page":"Rivi\u00e8re du Rempart District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"cd429455efff09b4cc978c2dc9e24769",
+    "wof:geomhash":"31cd91a11922ac104066b161b8a64fa7",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -291,7 +293,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846511,
+    "wof:lastmodified":1695884325,
     "wof:name":"Rivi\u00e8re du Rempart",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/83/85674983.geojson
+++ b/data/856/749/83/85674983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027535,
-    "geom:area_square_m":319249709.663284,
+    "geom:area_square_m":319250377.532467,
     "geom:bbox":"57.303477,-20.507013,57.488024,-20.161554",
     "geom:latitude":-20.33934,
     "geom:longitude":57.407082,
@@ -274,14 +274,16 @@
         "gn:id":934718,
         "gp:id":2346228,
         "hasc:id":"MU.BL",
+        "iso:code":"MU-BL",
         "iso:id":"MU-BL",
         "qs_pg:id":1083849,
         "unlc:id":"MU-BL",
         "wd:id":"Q873740",
         "wk:page":"Rivi\u00e8re Noire District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"3606acad9ff384942d7f229733af40c4",
+    "wof:geomhash":"d374e972f3d7a77aa8fb81eae7e5f638",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -298,7 +300,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846511,
+    "wof:lastmodified":1695884325,
     "wof:name":"Rivi\u00e8re Noire",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/89/85674989.geojson
+++ b/data/856/749/89/85674989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008553,
-    "geom:area_square_m":99561708.746346,
+    "geom:area_square_m":99561417.824044,
     "geom:bbox":"63.332286,-19.767185,63.493907,-19.669854",
     "geom:latitude":-19.712535,
     "geom:longitude":63.410501,
@@ -344,13 +344,15 @@
         "gn:id":1547449,
         "gp:id":2346239,
         "hasc:id":"MU.RO",
+        "iso:code":"MU-RO",
         "iso:id":"MU-RO",
         "qs_pg:id":219579,
         "wd:id":"Q208668",
         "wk:page":"Rodrigues"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"5301293205b7ad20e87f6b1f98a96542",
+    "wof:geomhash":"376d45136c6a53989476af193dec7494",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -367,7 +369,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846509,
+    "wof:lastmodified":1695884855,
     "wof:name":"Rodrigues",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/93/85674993.geojson
+++ b/data/856/749/93/85674993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020575,
-    "geom:area_square_m":238356516.906173,
+    "geom:area_square_m":238356219.357265,
     "geom:bbox":"57.391376,-20.517348,57.630974,-20.39605",
     "geom:latitude":-20.461808,
     "geom:longitude":57.517202,
@@ -278,14 +278,16 @@
         "gn:id":934017,
         "gp:id":2346236,
         "hasc:id":"MU.SA",
+        "iso:code":"MU-SA",
         "iso:id":"MU-SA",
         "qs_pg:id":423829,
         "unlc:id":"MU-SA",
         "wd:id":"Q1053600",
         "wk:page":"Savanne District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
-    "wof:geomhash":"4d84c3e2110ba2e7bb8cf4e246dc6d14",
+    "wof:geomhash":"7d60058c898d147ca7c9d35cfca0acb9",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -302,7 +304,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690846509,
+    "wof:lastmodified":1695884855,
     "wof:name":"Savanne",
     "wof:parent_id":85632357,
     "wof:placetype":"region",

--- a/data/856/749/97/85674997.geojson
+++ b/data/856/749/97/85674997.geojson
@@ -245,11 +245,13 @@
         "gn:id":933945,
         "gp:id":1377510,
         "hasc:id":"MU.",
+        "iso:code":"MU-VP",
         "qs_pg:id":492847,
         "unlc:id":"MU-VP",
         "wd:id":"Q676724",
         "wk:page":"Vacoas-Phoenix"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MU",
     "wof:geomhash":"25d13b831e34ed3a9b91729d7b7c0229",
     "wof:hierarchy":[
@@ -268,7 +270,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884286,
     "wof:name":"Vacoas-Phoenix",
     "wof:parent_id":85632357,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.